### PR TITLE
fix: simplify logger by removing the file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An MCP (Model Context Protocol) server implementation for ProtoGaia, supporting 
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Integrate with Claude Desktop](#integrate-with-claude-desktop)
   - [Using Stdio Method](#using-stdio-method)
   - [Using SSE Method](#using-sse-method)
 - [Understanding MCP](#understanding-mcp)
@@ -55,6 +56,58 @@ gaia-mcp-server stdio --api-key=your-api-key
 ## Usage
 
 The server can be run in two modes: stdio or SSE. You can choose which mode to run using the command-line interface.
+
+### Integrate with Claude Desktop
+
+You can integrate Gaia MCP Server with Claude Desktop to generate images directly in your conversations:
+
+1. **Get Your Gaia API Key**:
+   - Log in to [Gaia's website](https://protogaia.com)
+   - Go to your account settings via your profile picture
+   - Navigate to the "Security" section
+   - Create a new API key and copy it
+
+2. **Configure Claude Desktop**:
+   - Open Claude Desktop
+   - Go to Settings (File > Settings on Windows, Claude > Settings on Mac)
+   - Click the "Developer" tab
+   - Click the "Edit config" button
+   - Replace the content with one of these configurations:
+
+   **If you've installed the package globally**:
+   ```json
+   {
+     "mcpServers": {
+       "gaia-mcp-server": {
+         "command": "gaia-mcp-server",
+         "args": ["stdio", "--api-key=YOUR_GAIA_API_KEY"]
+       }
+     }
+   }
+   ```
+
+   **If you prefer to use npx (no installation)**:
+   ```json
+   {
+     "mcpServers": {
+       "gaia-mcp-server": {
+         "command": "npx",
+         "args": ["gaia-mcp-server", "stdio", "--api-key=YOUR_GAIA_API_KEY"]
+       }
+     }
+   }
+   ```
+
+   Replace `YOUR_GAIA_API_KEY` with your actual Gaia API key.
+
+3. **Restart Claude Desktop**
+
+4. **Test the Integration**:
+   - Start a new conversation
+   - Ask Claude to generate an image (e.g., "Generate an image of a sunset over mountains")
+   - You should see the image appear in your conversation
+
+For more detailed instructions and troubleshooting, see our [Claude Desktop Integration Guide](docs/claude-desktop-stdio-integration-guide.md).
 
 ### Using Stdio Method
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ program
     const gaiaMcpServer = new GaiaMcpServer({
       apiUrl: config.getEnv('GaiaApiUrl') ?? DEFAULT_GAIA_API_URL,
       logger,
+      version: packageJson.version,
     });
 
     const redisClient = new RedisClient({
@@ -61,6 +62,7 @@ program
       apiUrl: options.apiUrl ?? config.getEnv('GaiaApiUrl') ?? DEFAULT_GAIA_API_URL,
       apiKey: options.apiKey,
       logger,
+      version: packageJson.version,
     });
 
     await gaiaMcpServer.startStdio();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -43,6 +43,7 @@ type GaiaMcpServerOptions = {
   apiUrl: string;
   apiKey?: string;
   logger?: Logger;
+  version?: string;
 };
 
 /**
@@ -74,12 +75,12 @@ export class GaiaMcpServer {
    * @param options.logger - Optional custom logger instance
    */
   constructor(options: GaiaMcpServerOptions) {
-    const { apiUrl, apiKey, logger } = options;
+    const { apiUrl, apiKey, logger, version } = options;
 
     this.server = new McpServer(
       {
         name: 'GaiaMcpServer',
-        version: '0.0.1',
+        version: version || 'unknown',
       },
       {
         capabilities: {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,18 +1,15 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+// No imports needed for silent mode
 
 import { pino } from 'pino';
 
 /**
  * Creates and configures the application logger
  *
- * When the log level is set to 'silent', logs will be written to a file in the 'logs' directory
- * instead of being displayed in the console. For all other log levels, logs will be formatted
- * with pino-pretty and displayed in the console.
+ * When the log level is set to 'silent', logging is skipped entirely.
+ * For all other log levels, logs will be formatted with pino-pretty and displayed in the console.
  *
  * @param options Additional logger configuration options
- * @param options.name Optional name for the logger instance (used as the log filename when level is 'silent')
+ * @param options.name Optional name for the logger instance
  * @param options.level Optional logging level (defaults to process.env.LOG_LEVEL or 'info')
  * @returns Configured Pino logger instance
  */
@@ -20,31 +17,10 @@ export function createLogger(options?: { name?: string; level?: string }) {
   const level = options?.level || process.env.LOG_LEVEL || 'info';
 
   if (level === 'silent') {
-    // Get the absolute path to the server directory using import.meta.url (ES modules)
-    const currentFilePath = fileURLToPath(import.meta.url);
-    const currentDir = path.dirname(currentFilePath);
-    const serverDir = path.resolve(currentDir, '..', '..');
-
-    // Create log directory if it doesn't exist
-    const logDir = path.join(serverDir, 'logs');
-    if (!fs.existsSync(logDir)) {
-      fs.mkdirSync(logDir, { recursive: true });
-    }
-
-    const fileName = (options?.name || 'app').replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-
-    const transport = {
-      target: 'pino/file',
-      options: {
-        destination: path.join(logDir, `${fileName}.log`),
-        mkdir: true,
-      },
-    };
-
+    // When level is silent, return a logger that skips logging entirely
     return pino({
       name: options?.name,
       level,
-      transport,
     });
   } else {
     const transport = {


### PR DESCRIPTION
- Simplify the logger by removing the file output to avoid permission denied on end-user machine.
- Update the README by adding the guide to integrate with Claude Desktop.
- Improve the MCP server with version info.